### PR TITLE
feat: add support for endpoint token and cert configuration

### DIFF
--- a/core/cli/configure.go
+++ b/core/cli/configure.go
@@ -102,7 +102,25 @@ func runE(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.New(url)
+	token, err := tui.StringPrompt("enter permify token", "", config.CliConfig.Token)
+	if err != nil {
+		return err
+	}
+
+	certPath, err := tui.StringPrompt("enter cert path", "", config.CliConfig.CertPath)
+	if err != nil {
+		return err
+	}
+
+	certKey, err := tui.StringPrompt("enter cert key", "", config.CliConfig.CertKey)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.New(url, token, certPath, certKey)
+	if err != nil {
+		return err
+	}
 
 	// Todo: Implement pagination
 	tenants, err := resp.Tenancy.List(context.Background(), &v1.TenantListRequest{})
@@ -122,8 +140,12 @@ func runE(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		logger.Log.Error(err)
 	}
+
 	config.CliConfig.PermifyURL = url
 	config.CliConfig.Tenant = tenantIds[tenant]
+	config.CliConfig.Token = token
+	config.CliConfig.CertPath = certPath
+	config.CliConfig.CertKey = certKey
 	err = config.Write()
 	if err != nil {
 		logger.Log.Error(err)

--- a/core/client/grpc.go
+++ b/core/client/grpc.go
@@ -2,19 +2,58 @@
 package client
 
 import (
+	"context"
+	"crypto/tls"
+
 	permify "github.com/Permify/permify-go/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 // New initializes a new permify client
-func New(endpoint string) (*permify.Client, error) {
+func New(endpoint string, token string, certPath string, certKey string) (*permify.Client, error) {
+	var opts []grpc.DialOption
+
+	if certPath != "" {
+		var creds credentials.TransportCredentials
+		if certKey != "" {
+			certificate, err := tls.LoadX509KeyPair(certPath, certKey)
+			if err != nil {
+				return nil, err
+			}
+			creds = credentials.NewTLS(&tls.Config{
+				Certificates: []tls.Certificate{certificate},
+			})
+		} else {
+			var err error
+			creds, err = credentials.NewClientTLSFromFile(certPath, "")
+			if err != nil {
+				return nil, err
+			}
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	if token != "" {
+		opts = append(opts, grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}))
+		opts = append(opts, grpc.WithStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+			return streamer(ctx, desc, cc, method, opts...)
+		}))
+	}
+
 	client, err := permify.NewClient(
 		permify.Config{
 			Endpoint: endpoint,
 		},
-		// Todo: Implement secure call with tls certificate
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		opts...,
 	)
 	return client, err
 }

--- a/core/cmd/data/client.go
+++ b/core/cmd/data/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Client() v1.DataClient {
-	c, err := client.New(config.CliConfig.PermifyURL)
+	c, err := client.New(config.CliConfig.PermifyURL, config.CliConfig.Token, config.CliConfig.CertPath, config.CliConfig.CertKey)
 	if err != nil {
 		log.Error("Error initializing permify client. Check the configuration or rerun `permify configure`")
 		os.Exit(-1)	

--- a/core/cmd/permission/client.go
+++ b/core/cmd/permission/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Client() v1.PermissionClient {
-	c, err := client.New(config.CliConfig.PermifyURL)
+	c, err := client.New(config.CliConfig.PermifyURL, config.CliConfig.Token, config.CliConfig.CertPath, config.CliConfig.CertKey)
 	if err != nil {
 		log.Error("Error initializing permify client. Check the configuration or rerun `permify configure`")
 		os.Exit(-1)	

--- a/core/cmd/schema/client.go
+++ b/core/cmd/schema/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Client() v1.SchemaClient {
-	c, err := client.New(config.CliConfig.PermifyURL)
+	c, err := client.New(config.CliConfig.PermifyURL, config.CliConfig.Token, config.CliConfig.CertPath, config.CliConfig.CertKey)
 	if err != nil {
 		log.Error("Error initializing permify client. Check the configuration or rerun `permify configure`")
 		os.Exit(-1)	

--- a/core/cmd/tenancy/client.go
+++ b/core/cmd/tenancy/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Client() v1.TenancyClient {
-	c, err := client.New(config.CliConfig.PermifyURL)
+	c, err := client.New(config.CliConfig.PermifyURL, config.CliConfig.Token, config.CliConfig.CertPath, config.CliConfig.CertKey)
 	if err != nil {
 		log.Error("Error initializing permify client. Check the configuration or rerun `permify configure`")
 		os.Exit(-1)	

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -27,6 +27,9 @@ type ProfileConfigs struct {
 type CoreConfig struct {
 	PermifyURL			 string  `yaml:"permify_url"`
 	Tenant 				 string  `yaml:"tenant"`
+	Token				 string  `yaml:"token"`
+	CertPath			 string  `yaml:"cert_path"`
+	CertKey				 string  `yaml:"cert_key"`
 	SslEnabled           bool    `yaml:"-"`
 }
 


### PR DESCRIPTION
This PR adds support for configuring the Permify endpoint, token, and certificate paths in the CLI. This allows for secure gRPC connections using TLS and authentication via bearer tokens. 

Fixes #2 
/attempt #2